### PR TITLE
Allows movement of joystick when clicking the small circle

### DIFF
--- a/Sources/OMJoyStick.swift
+++ b/Sources/OMJoyStick.swift
@@ -252,7 +252,7 @@ public struct OMJoystick: View {
                         bigRingStrokeColor: bigRingStrokeColor,
                         bigRingDiameter: bigRingDiameter).gesture(dragGesture)
                     
-                    SmallRing(smallRingDiameter: self.smallRingDiameter, subRingColor: subRingColor).offset(x: smallRingLocationX, y: smallRingLocationY)
+                    SmallRing(smallRingDiameter: self.smallRingDiameter, subRingColor: subRingColor).offset(x: smallRingLocationX, y: smallRingLocationY).allowsHitTesting(false)
                 }
                 
                 rightIcon?.renderingMode(.template)


### PR DESCRIPTION
Resolves #5

Simply disallows hit testing on the SmallRing, thus calling dragGesture on the BigRing when SmallRing is touched.